### PR TITLE
Process files/chunks in sorted order

### DIFF
--- a/scripts/build_filtered_chunks.py
+++ b/scripts/build_filtered_chunks.py
@@ -174,6 +174,7 @@ def process_chunk_list(gov2, filter, root, mg4j, bitfunnel, min_postings, max_po
 
     r = re.compile(filter)
     basenames = [x for x in unfiltered_basenames if r.match(x)]
+    basenames.sort()
 
     print("Processing {0} chunks.".format(len(basenames)))
 

--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -497,6 +497,7 @@ class Experiment:
                   for root, dirs, files in os.walk(self.chunk_dir)
                   for f in files
                   if regex.search(f) is not None]
+        chunks.sort()
 
         for chunk in chunks:
             print(chunk)


### PR DESCRIPTION
Indexing documents in a specific order can affect the performance
of BEF and Bitfunnel. These changes force files on disk to be
processed in sorted order to allow processing URL sorted collections.